### PR TITLE
Make Zero2Production compatibe with Flightcontrol's deployment configuration

### DIFF
--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -2,13 +2,6 @@ application:
   port: 8000
   host: 0.0.0.0
   hmac_secret: "super-long-and-secret-random-key-needed-to-verify-message-integrity"
-database:
-  host: "127.0.0.1"
-  port: 5432
-  username: "postgres"
-  password: "password"
-  database_name: "newsletter"
-  require_ssl: false
 email_client:
   base_url: "localhost"
   sender_email: "test@gmail.com"

--- a/configuration/local.yaml
+++ b/configuration/local.yaml
@@ -2,4 +2,5 @@ application:
   host: 127.0.0.1
   base_url: "http://127.0.0.1"
 database:
-  require_ssl: false
+  uri: postgresql://postgres:password@127.0.0.1:5432
+  database_name: "newsletter"

--- a/configuration/production.yaml
+++ b/configuration/production.yaml
@@ -1,6 +1,4 @@
 application:
   host: 0.0.0.0
-database:
-  require_ssl: true
 email_client:
   base_url: "https://api.postmarkapp.com"

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -188,7 +188,7 @@ pub async fn spawn_app() -> TestApp {
     let configuration = {
         let mut c = get_configuration().expect("Failed to read configuration.");
         // Use a different database for each test case
-        c.database.database_name = Uuid::new_v4().to_string();
+        c.database.database_name = Some(Uuid::new_v4().to_string());
         // Use a random OS port
         c.application.port = 0;
         // Use the mock server as email API
@@ -233,7 +233,7 @@ async fn configure_database(config: &DatabaseSettings) -> PgPool {
         .await
         .expect("Failed to connect to Postgres");
     connection
-        .execute(&*format!(r#"CREATE DATABASE "{}";"#, config.database_name))
+        .execute(&*format!(r#"CREATE DATABASE "{}";"#, config.database_name.as_ref().expect("Expected database name to be set during testing")))
         .await
         .expect("Failed to create database.");
 


### PR DESCRIPTION
Flightcontrol uses environment variables to communicate data from AWS to our application so some changes are needed to properly handle those environment variables.